### PR TITLE
Issue #23 - Remove "-r" CLI Argument

### DIFF
--- a/fsociety/information_gathering/sherlock.py
+++ b/fsociety/information_gathering/sherlock.py
@@ -21,7 +21,7 @@ class SherlockRepo(GitHubRepo):
         for username in user_usernames.split():
             if username not in usernames:
                 add_username(username)
-        return os.system(f"python3 sherlock {user_usernames} -r")
+        return os.system(f"python3 sherlock {user_usernames}")
 
 
 sherlock = SherlockRepo()


### PR DESCRIPTION
Updated sherlock.py to reflect a change in Sherlock that no longer requires the CLI argument "-r".

Closes #23 