### PR TITLE
fix: add `requirements.txt`/`requirements-dev.txt` for `MANIFEST.in`

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
 include *.md LICENSE
+include requirements.txt
+include requirements-dev.txt


### PR DESCRIPTION
👋 right now the pypi tarball missing requirements.txt

```
~/D/l/fsociety-3.2.9 > tree -L 1 .
.
├── CHANGELOG.md
├── fsociety
├── fsociety.egg-info
├── LICENSE
├── MANIFEST.in
├── PACKAGES.md
├── PKG-INFO
├── pyproject.toml
├── README.md
├── setup.cfg
└── setup.py

3 directories, 9 files
```

updating the `MANIFEST.in` to include `requirements.txt` to fix 

```
      File "/private/tmp/pip-build-env-ao6jhlos/overlay/lib/python3.13/site-packages/setuptools/build_meta.py", line 320, in run_setup
        exec(code, locals())
        ~~~~^^^^^^^^^^^^^^^^
      File "<string>", line 82, in <module>
      File "<string>", line 39, in get_requirements
    FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
    error: subprocess-exited-with-error
    
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> See above for output.
```